### PR TITLE
wildcard expansion throwing an "arguments too long" error

### DIFF
--- a/modules/nf-core/vsearch/cluster/main.nf
+++ b/modules/nf-core/vsearch/cluster/main.nf
@@ -60,7 +60,7 @@ process VSEARCH_CLUSTER {
 
     if [[ $args3 == "--clusters" ]]
     then
-        gzip -n ${prefix}.${out_ext}*
+        find . -name \"${prefix}.${out_ext}*[0-9]\" | xargs gzip -n
     elif [[ $args3 != "--samout" ]]
     then
         gzip -n ${prefix}.${out_ext}


### PR DESCRIPTION
`gzip -n ${prefix}.${out_ext}*` was throwing an "arguments too long" error.  

I've fixed it by using `find` to get all the needed files and pipe them to `xargs gzip`.  It was still acting oddly on my computer (some files ended up with two, three, or four ".gz"'s at the end - so it must have been passing some files to gzip multiple times). That was easily fixed by adding the regex for a single digit (`[0-9]`) at the end of the `find` pattern so it would ignore files that ended in .gz.


## PR checklist


- [ yes] This comment contains a description of changes (with reason).
- [ no] If you've fixed a bug or added code that should be tested, add tests! --> I ran the tests on my data using my hpc. Unfortunately, the testcase is pretty big (needing to generate the arguments too long error, so I've not added any test data. Happy to discuss if needed though.
- [ no] If necessary, include test data in your PR.
- [ yes] Add a resource `label`
